### PR TITLE
Fix KeyError when accessing empty value_counts() Series

### DIFF
--- a/src/epic_scraper/epicfileimport/epic_module.py
+++ b/src/epic_scraper/epicfileimport/epic_module.py
@@ -337,9 +337,9 @@ def growth_time(df):
                         'End of the Growth: '
                         + df.index[-1].strftime('%Y-%m-%d %H:%M:%S')
                     )
-                if len(df.index) % 2 == 0:
+                if len(df.index) > 0 and len(df.index) % 2 == 0:
                     df.grow = (
-                        str(df['object'].value_counts()[0])
+                        str(df['object'].value_counts().iloc[0])
                         + ' growths detected with the names '
                         + ','.join(df['object'].value_counts().index.values.tolist())
                         + '.'


### PR DESCRIPTION
The growth_time() function was failing with a KeyError when trying to access index 0 of an empty value_counts() Series. This occurred when the dataframe had length 0 (which satisfies len(df.index) % 2 == 0).

Changes:
- Added check for len(df.index) > 0 before accessing value_counts()[0]
- Changed positional indexing from [0] to .iloc[0] to avoid FutureWarning

This fixes the issue where parsing would fail with:
  KeyError: 0
  at df['object'].value_counts()[0]

This fix has been tested with https://github.com/PDI-Berlin/PDI-NOMAD-Oasis-image (main branch) and https://github.com/PDI-Berlin/pdi-nomad-plugin (main branch), with the test m8test_pdi.zip

<img width="1226" height="526" alt="Screenshot from 2026-01-06 14-34-36" src="https://github.com/user-attachments/assets/9a3a5a20-c164-4c5d-96e9-7b42415f13f2" />

<img width="861" height="1895" alt="Screenshot from 2026-01-06 14-35-27" src="https://github.com/user-attachments/assets/5b8bb427-9436-41ca-8fb3-3fecfbdbb832" />
